### PR TITLE
feat(protobuf): enable matrix for protobuf 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,23 @@ sudo: required
 services:
   - docker
 
+env:
+  global:
+    - DOCKER_REPO='ojkwon/arch-emscripten'
+  matrix:
+    - BUILD_TARGET='base'
+    - BUILD_TARGET='protobuf'
+
 matrix:
   # let whole build fails if one of matrix build config fails
   fast_finish: true
 
-  include:
-    - env:
-      - DOCKER_REPO='ojkwon/arch-emscripten'
-
 script:
   - COMMIT=${TRAVIS_COMMIT::8}
   # set docker tag based on last commit short sha.
-  - DOCKER_TAG=$DOCKER_REPO:${COMMIT}
+  - DOCKER_TAG=$DOCKER_REPO:${COMMIT}-$BUILD_TARGET
   - tput setaf 2; echo building docker image tagged as $DOCKER_TAG
-  - sudo docker build --tag $DOCKER_TAG .
+  - sudo docker build --tag $DOCKER_TAG --build-arg BUILD_TARGET=$BUILD_TARGET .
   - |
     if [[ ! -z "${TRAVIS_TAG}" ]]; then
       tput setaf 2; echo this build is tagged versioned build, pushing into registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM ojkwon/arch-nvm-node:4032238-node7.9-npm4
 MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
+# Build time args
+ARG BUILD_TARGET=""
+
 # Install dependencies
 RUN pacman --noconfirm -Syu \
   emscripten \
-  python \
   unzip \
+  python \
   python-setuptools \
   python2-setuptools \
   jre8-openjdk
@@ -15,4 +18,24 @@ SHELL ["/bin/bash", "-l", "-c"]
 
 # Initialize emcc
 RUN emcc
+
+USER builder
+
+# Install 3.1 version of protobuf via makepkg instead of latest, to align with
+# protobuf-emscripten. Also build emscripten-protobuf as well, place build under
+# /home/builder/temp/.libs
+RUN if [[ "${BUILD_TARGET}" == "protobuf" ]]; then \
+    echo "installing protobuf 3.1 dependency" && \
+    mkdir $TMPDIR/proto31 && cd $TMPDIR/proto31 && \
+    curl "https://git.archlinux.org/svntogit/packages.git/plain/trunk/PKGBUILD?h=packages/protobuf&id=fa8b9da391b26b6ace1941e9871a6416db74d67b" > ./PKGBUILD && \
+    makepkg && sudo pacman --noconfirm -U *.pkg.tar.xz && \
+    cd $TMPDIR && git clone https://github.com/kwonoj/protobuf-emscripten && \
+    cd $TMPDIR/protobuf-emscripten/3.1.0 && \
+    sh autogen.sh && emconfigure ./configure && emmake make && \
+    cp -r ./src/.libs $TMPDIR/ && \
+    ls $TMPDIR/.libs; \
+  fi
+
+USER root
+
 CMD emcc --version


### PR DESCRIPTION
This PR enables build matrix to include protobuf 3.1 (specifcally, instead of latest) for certain build usecases. 