### PR TITLE
feat(preamble): support node.js getBinary on Electron renderer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM ojkwon/arch-nvm-node:4032238-node7.9-npm4
+FROM ojkwon/arch-nvm-node:7b0d30e-node8.4-npm5.4.1
 MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
 # Build time args
 ARG BUILD_TARGET=""
 
+# Upgrade system
+RUN pacman --noconfirm -Syyu
+
 # Install dependencies
-RUN pacman --noconfirm -Syu \
+RUN pacman --noconfirm -S \
   emscripten \
   unzip \
   python \
@@ -15,6 +18,12 @@ RUN pacman --noconfirm -Syu \
 
 # Change subsequent execution shell to bash
 SHELL ["/bin/bash", "-l", "-c"]
+
+# Patch preamble.js to support Electron's renderer process with node.js environment
+# Refer https://github.com/kripken/emscripten/pull/5577 for detail.
+# TODO: remove based on upstream PR status
+COPY ./preamble.patch $TMPDIR/
+RUN patch /usr/lib/emscripten/src/preamble.js $TMPDIR/preamble.patch
 
 # Initialize emcc
 RUN emcc

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN if [[ "${BUILD_TARGET}" == "protobuf" ]]; then \
     echo "installing protobuf 3.1 dependency" && \
     mkdir $TMPDIR/proto31 && cd $TMPDIR/proto31 && \
     curl "https://git.archlinux.org/svntogit/packages.git/plain/trunk/PKGBUILD?h=packages/protobuf&id=fa8b9da391b26b6ace1941e9871a6416db74d67b" > ./PKGBUILD && \
-    makepkg && sudo pacman --noconfirm -U *.pkg.tar.xz && \
+    makepkg --skipchecksums && sudo pacman --noconfirm -U *.pkg.tar.xz && \
     cd $TMPDIR && git clone https://github.com/kwonoj/protobuf-emscripten && \
     cd $TMPDIR/protobuf-emscripten/3.1.0 && \
     sh autogen.sh && emconfigure ./configure && emmake make && \

--- a/preamble.patch
+++ b/preamble.patch
@@ -1,0 +1,15 @@
+diff --git a/src/preamble.js b/src/preamble.js
+index 70145dc0f..50b8e73c0 100644
+--- a/src/preamble.js
++++ b/src/preamble.js
+@@ -2231,7 +2231,9 @@ function integrateWasmJS(Module) {
+ 
+   function getBinaryPromise() {
+     // if we don't have the binary yet, and have the Fetch api, use that
+-    if (!Module['wasmBinary'] && typeof fetch === 'function') {
++    // if Module overridded its environment to Node in Electron's renderer process, do not use fetch
++    var electronNodeContext = Module["ENVIRONMENT"] === "NODE" && !!window.process && !!window.require;
++    if (!Module['wasmBinary'] && typeof fetch === 'function' && !electronNodeContext) {
+       return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function(response) {
+         if (!response['ok']) {
+           throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";


### PR DESCRIPTION
This PR patches `preamble.js` in emscripten directly, using changes in https://github.com/kripken/emscripten/pull/5577 to support load wasm binary via `getBinary` instead of `fetch` on Electron's renderer process when environment is set to `NODE` explicitly.